### PR TITLE
update networkx dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='birankpy',
       url="https://github.com/BrianAronson/birankr",
       license = 'MIT',
       install_requires=[
-          'networkx==2.2',
+          'networkx>=2.5',
           'pandas>=0.23.4',
           'numpy>=1.16.2',
           'scipy>=1.2.0'


### PR DESCRIPTION
Attempt to work around https://github.com/BrianAronson/birankr/issues/30

I tested this locally with Python 3.9 and everything worked. It seems there is no need to pin to the old `networkx` version.